### PR TITLE
Add time parameters

### DIFF
--- a/krcal/core/fit_functions.py
+++ b/krcal/core/fit_functions.py
@@ -306,3 +306,12 @@ def fit_slices_2d_expo(xdata, ydata, zdata, tdata,
             except:
                 pass
     return Measurement(const, constu), Measurement(slope, slopeu), chi2, valid
+    
+    
+def sigmoid(x          : np.array,
+            scale      : float,
+            inflection : float,
+            slope      : float,
+            offset     : float)->np.array:
+    
+    return scale / ( 1 + np.exp( - slope * ( x - inflection ) ) ) + offset

--- a/krcal/core/fit_functions.py
+++ b/krcal/core/fit_functions.py
@@ -15,11 +15,14 @@ import warnings
 from typing      import List, Tuple, Sequence, Iterable, Callable
 
 import invisible_cities.core .fit_functions  as     fitf
+import invisible_cities.database.load_db     as     DB
 from   invisible_cities.core .core_functions import in_range
 from   invisible_cities.evm  .ic_containers  import Measurement
 from   invisible_cities.icaro.hst_functions  import shift_to_bin_centers
 from   invisible_cities.icaro.hst_functions  import labels
-from   invisible_cities.evm.ic_containers import FitFunction
+from   invisible_cities.evm.ic_containers    import FitFunction
+from   invisible_cities.core.stat_functions  import poisson_sigma
+
 
 
 def chi2f(f   : Callable,
@@ -315,3 +318,56 @@ def sigmoid(x          : np.array,
             offset     : float)->np.array:
     
     return scale / ( 1 + np.exp( - slope * ( x - inflection ) ) ) + offset
+
+
+def compute_drift_v(zdata    : np.array,
+                    nbins    : int                               = 35,
+                    zrange   : Tuple[float, float]               = (500, 640),
+                    seed     : Tuple[float, float, float, float] = None,
+                    detector : str                               = 'new',
+                    plot_fit : bool                              = False)->Tuple[float, float]:
+    """
+    Computes the drift velocity for a given distribution
+    using the sigmoid function to get the cathode edge.
+
+    Parameters
+    ----------
+    zdata: array_like
+        Values of Z coordinate.
+    nbins: int (optional)
+        The number of bins in the z coordinate for the binned fit.
+    zrange: length-2 tuple (optional)
+        Fix the range in z.
+    seed: length-4 tuple (optional)
+        Seed for the fit.
+    detector: string (optional)
+        Used to get the cathode position from DB.
+    plot_fit: boolean (optional)
+        Flag for plotting the results.
+
+    Returns
+    -------
+    dv: float
+        Drift velocity.
+    dvu: float
+        Drift velocity uncertainty.
+    """
+
+    y, x = np.histogram(zdata, nbins, zrange)
+    x    = shift_to_bin_centers(x)
+
+    if seed is None: seed = np.max(y), np.mean(zrange), 0.5, np.min(y)
+
+    f = fitf.fit(sigmoid, x, y, seed, sigma=poisson_sigma(y), fit_range=zrange)
+
+    z_cathode = DB.DetectorGeo(detector).ZMAX[0]
+    dv        = z_cathode/f.values[1]
+    dvu       = dv / f.values[1] * f.errors[1]
+
+    if plot_fit:
+        plt.figure();
+        plt.hist(zdata, nbins, zrange)
+        xx = np.linspace(zrange[0], zrange[1], nbins)
+        plt.plot(xx, sigmoid(xx, *f[1]), color='red');
+
+    return dv, dvu

--- a/krcal/core/fit_functions_test.py
+++ b/krcal/core/fit_functions_test.py
@@ -1,0 +1,35 @@
+"""
+Tests for fit_functions
+"""
+
+import numpy as np
+
+from pytest                import approx
+
+from hypothesis            import given
+from hypothesis.strategies import floats
+
+from . fit_functions       import sigmoid
+
+
+@given(floats(min_value = -1e4,
+              max_value = +1e4),
+       floats(min_value = -1e4,
+              max_value = + 1e4))
+def test_sigmoid_limits(A, D):
+    aux_sigmoid = lambda x: sigmoid(x, A, 0, 10, D)
+    assert aux_sigmoid(-10) == approx(D  , rel=1e-2)
+    assert aux_sigmoid( 10) == approx(A+D, rel=1e-2)
+
+@given(floats(min_value = -1e4,
+              max_value = +1e4),
+       floats(min_value = -1e4,
+              max_value = + 1e4),
+       floats(min_value = -1e2,
+              max_value = + 1e2),
+       floats(min_value = -1e4,
+              max_value = + 1e4))
+def test_sigmoid_values_at_abscissa_axis(A, B, C, D):
+    value = sigmoid(0, A, B, C, D)
+    test  = A / (1 + np.exp(B*C)) + D
+    assert value == test

--- a/krcal/core/fit_functions_test.py
+++ b/krcal/core/fit_functions_test.py
@@ -2,14 +2,18 @@
 Tests for fit_functions
 """
 
-import numpy as np
+import numpy                                as np
 
-from pytest                import approx
+from   pytest                               import approx
 
-from hypothesis            import given
-from hypothesis.strategies import floats
+from   hypothesis                           import given
+from   hypothesis.strategies                import floats
 
-from . fit_functions       import sigmoid
+from   invisible_cities.evm  .ic_containers import Measurement
+import invisible_cities.database.load_db    as     DB
+
+from . fit_functions                        import sigmoid
+from . fit_functions                        import compute_drift_v
 
 
 @given(floats(min_value = -1e4,
@@ -33,3 +37,16 @@ def test_sigmoid_values_at_abscissa_axis(A, B, C, D):
     value = sigmoid(0, A, B, C, D)
     test  = A / (1 + np.exp(B*C)) + D
     assert value == test
+
+@given(floats(min_value = 530,
+              max_value = 570))
+def test_compute_drift_v_when_moving_edge(edge):
+    Nevents = 100*1000
+    data    = np.random.uniform(450, edge, Nevents)
+    data    = np.random.normal(data, 1)
+    dv, dvu = compute_drift_v(data, 60, [500,600],
+                              [1500, 550,1,0], 'new',
+                              plot_fit=False)
+    dv_th   = DB.DetectorGeo('new').ZMAX[0]/edge
+
+    assert dv_th == approx(dv, abs=5*dvu)

--- a/krcal/core/kr_parevol_functions.py
+++ b/krcal/core/kr_parevol_functions.py
@@ -1,0 +1,107 @@
+from . fit_lt_functions     import fit_lifetime_profile
+from . correction_functions import e0_xy_correction
+from . fit_functions        import compute_drift_v
+from . map_functions        import amap_max
+from . kr_types             import ASectorMap
+
+from   typing               import List, Tuple
+
+import pandas as pd
+import numpy  as np
+
+
+def computing_kr_parameters(data       : pd.DataFrame,
+                            ts         : float,
+                            emaps      : ASectorMap,
+                            xr_map     : Tuple[float, float],
+                            yr_map     : Tuple[float, float],
+                            nx_map     : int,
+                            ny_map     : int,
+                            zslices_lt : int,
+                            zrange_lt  : Tuple[float,float]  = (0, 550),
+                            nbins_dv   : int                 = 35,
+                            zrange_dv  : Tuple[float, float] = (500, 625),
+                            detector   : str                 = 'new',
+                            plot_fit   : bool                = False)->pd.DataFrame:
+
+    """
+    Computes some average parameters (e0, lt, drift v,
+    S1w, S1h, S1e, S2w, S2h, S2e, S2q, Nsipm, 'Xrms, Yrms)
+    for a given krypton distribution. Returns a DataFrame.
+
+    Parameters
+    ----------
+    data: DataFrame
+        Kdst distribution to analyze.
+    ts: float
+        Central time of the distribution.
+    emaps: correction map
+        Allows geometrical correction of the energy.
+    xr_map, yr_map: length-2 tuple
+        Set the X/Y-coordinate range of the correction map.
+    nx_map, ny_map: int
+        Set the number of X/Y-coordinate bins for the correction map.
+    zslices_lt: int
+        Number of Z-coordinate bins for doing the exponential fit to compute the lifetime
+    zrange_lt: length-2 tuple (optional)
+        Number of Z-coordinate range for doing the exponential fit to compute the lifetime
+    nbins_dv: int (optional)
+        Number of bins in Z-coordinate for doing the histogram to compute the drift velocity
+    zrange_dv: int (optional)
+        Range in Z-coordinate for doing the histogram to compute the drift velocity
+    detector: string (optional)
+        Used to get the cathode position from DB for the drift velocity computation.
+    plot_fit: boolean (optional)
+        Flag for plotting the Z-distribution of events around the cathode and the sigmoid fit.
+
+    Returns
+    -------
+    pars: DataFrame
+        Each column corresponds to the average value of a different parameter.
+    """
+
+    ## lt and e0
+    norm     = amap_max(emaps)
+    _, _, fr = fit_lifetime_profile(data.Z,
+                                    e0_xy_correction(data.S2e.values,
+                                                     data.X.values,
+                                                     data.Y.values,
+                                                     E0M=(emaps.e0/norm.e0),
+                                                     xr=xr_map, yr=yr_map,
+                                                     nx=nx_map, ny=ny_map),
+                                    zslices_lt, zrange_lt)
+    e0,  lt  = fr.par
+    e0u, ltu = fr.err
+
+    ## compute drift_v
+    dv, dvu  = compute_drift_v(data.Z, nbins=nbins_dv,
+                               zrange=zrange_dv, detector=detector,
+                               plot_fit=plot_fit)
+
+    ## average values
+    parameters = ['S1w', 'S1h', 'S1e', 'S2w', 'S2h', 'S2e', 'S2q', 'Nsipm', 'Xrms', 'Yrms']
+    mean_dict, var_dict = {}, {}
+    for parameter in parameters:
+        data_value           = getattr(data, parameter)
+        mean_dict[parameter] = np.mean(data_value)
+        var_dict [parameter] = (np.var(data_value)/len(data_value))**0.5
+
+    ## saving as pd.DataFrame
+    pars = pd.DataFrame({'ts':    [ts],
+                         'e0':    [e0],                 'e0u':    [e0u],
+                         'lt':    [lt],                 'ltu':    [ltu],
+                         'dv':    [dv],                 'dvu':    [dvu],
+                         's1w':   [mean_dict['S1w']],   's1wu':   [var_dict['S1w']],
+                         's1h':   [mean_dict['S1h']],   's1hu':   [var_dict['S1h']],
+                         's1e':   [mean_dict['S1e']],   's1eu':   [var_dict['S1e']],
+                         's2w':   [mean_dict['S2w']],   's2wu':   [var_dict['S2w']],
+                         's2h':   [mean_dict['S2h']],   's2hu':   [var_dict['S2h']],
+                         's2e':   [mean_dict['S2e']],   's2eu':   [var_dict['S2e']],
+                         's2q':   [mean_dict['S2q']],   's2qu':   [var_dict['S2q']],
+                         'Nsipm': [mean_dict['Nsipm']], 'Nsipmu': [var_dict['Nsipm']],
+                         'Xrms':  [mean_dict['Xrms']],  'Xrmsu':  [var_dict['Xrms']],
+                         'Yrms':  [mean_dict['Yrms']],  'Yrmsu':  [var_dict['Yrms']]})
+
+    return pars
+
+


### PR DESCRIPTION
This pull request, made by @bpalmeiro and myself, adds the functionality for computing the time evolution of several krypton parameters. Some functions were implemented in `core.fit_functions.py` and others in `core.kr_parevol_functions.py`. 

WIP: adding tests (ideas are welcome).

Performance is shown in: https://github.com/ausonandres/KrCalibNB/blob/show_time_evolution/krEvolutionNB/time_evolution_functions_test.ipynb