### PR TITLE
Add new config. files for high krypton rate and no checks options.

### DIFF
--- a/krcal/map_builder/config_HEcal.conf
+++ b/krcal/map_builder/config_HEcal.conf
@@ -10,7 +10,7 @@ ref_Z_histogram    = dict(
     key_Z_histo    = 'histo_Z_dst'                                                  )
 
 # run number 0 is for MC
-run_number = 7431
+run_number = '{runnumber}'
 
 # event selector control
 

--- a/krcal/map_builder/config_HEcal_HighKrRate.conf
+++ b/krcal/map_builder/config_HEcal_HighKrRate.conf
@@ -1,0 +1,72 @@
+folder             = '{folderin}'
+file_in            = '{filein}'
+file_bootstrap_map = '$ICDIR/database/test_data/kr_emap_xy_100_100_r_6573_time.h5'
+file_out_map       = '{fileoutmap}'
+file_out_hists     = '{fileouthist}'
+
+# High Energy Configuration File:
+ref_Z_histogram    = dict(
+    ref_histo_file = '$ICARO/krcal/map_builder/reference_files/z_dst_HE_HKr_mean_ref.h5',
+    key_Z_histo    = 'histo_Z_dst'                                                      )
+
+# run number 0 is for MC
+run_number = '{runnumber}'
+
+# event selector control
+
+quality_ranges  = dict(
+    r_max = 200 ) # Max R for initial quality cuts
+
+nS1_eff_min     = 0.7  # Min nS1==1 eff. to continue map production.
+nS1_eff_max     = 1.   # Max nS1==1 eff. to continue map production.
+
+nS2_eff_min     = 0.63 # Min nS2==1 eff. to continue map production.
+nS2_eff_max     = 1.   # Max nS2==1 eff. to continue map production.
+
+nsigmas_Zdst    = 10   # Number of sigmas to consider Z dst correct.
+
+n_dev_rate      = 5    # Number of rel. dev. to consider rate dst correct.
+
+band_sel_params = dict(
+    range_Z     = (10, 550)      ,  # Z range to apply selection.
+    range_E     = (10.0e+3,14e+3),  # Energy range to apply sel.
+    nbins_z     = 50             ,  # Number of bins in Z axis.
+    nbins_e     = 50             ,  # Number of bins in energy axis.
+    nsigma_sel  = 3.5            ,  # Number of sigmas to apply sel.
+    eff_min     = 0.53           ,  # Min eff. to continue map prod.
+    eff_max     = 0.93           )  # Max eff. to continue map prod.
+
+# get automatic binning
+thr_evts_for_sel_map_bins = 1e6    # Threshold to use 50 or 100 bins.
+default_n_bins            = None   # If not specified: n_bins=50 or 100.
+
+### Histograms params
+ns1_histo_params  = dict(
+    nbins_hist    = 10    ,
+    range_hist    = (0,10),
+    norm          = True  )
+
+ns2_histo_params  = dict(
+    nbins_hist    = 10    ,
+    range_hist    = (0,10),
+    norm          = True  )
+
+rate_histo_params = dict(
+    bin_size      = 180  ,
+    normed        = False)
+
+## Map parameters
+map_params        = dict(
+    nbins_z       = 15            ,
+    nbins_e       = 25            ,
+    z_range       = (10, 550)     ,
+    e_range       = (2000, 18000) ,
+    chi2_range    = (0,10)        ,
+    lt_range      = (1000, 15000) ,
+    nmin          = 100           ,
+    maxFailed     = 600           ,
+    r_max         = 200           ,
+    r_fid         = 100           ,
+    nStimeprofile = 1800          ,
+    x_range       = (-200,200)    ,
+    y_range       = (-200,200)    )

--- a/krcal/map_builder/config_LBphys.conf
+++ b/krcal/map_builder/config_LBphys.conf
@@ -10,7 +10,7 @@ ref_Z_histogram    = dict(
     key_Z_histo    = 'histo_Z_dst'                                                  )
 
 # run number 0 is for MC
-run_number = 7506
+run_number = '{runnumber}'
 
 # event selector control
 

--- a/krcal/map_builder/config_LBphys_run4.conf
+++ b/krcal/map_builder/config_LBphys_run4.conf
@@ -1,0 +1,72 @@
+folder             = '{folderin}'
+file_in            = '{filein}'
+file_bootstrap_map = '$ICDIR/database/test_data/kr_emap_xy_100_100_r_6573_time.h5'
+file_out_map       = '{fileoutmap}'
+file_out_hists     = '{fileouthist}'
+
+# Low Background Configuration File:
+ref_Z_histogram    = dict(
+    ref_histo_file = '$ICARO/krcal/map_builder/reference_files/z_dst_LB_run4_mean_ref.h5',
+    key_Z_histo    = 'histo_Z_dst'                                                       )
+
+# run number 0 is for MC
+run_number = '{runnumber}'
+
+# event selector control
+
+quality_ranges  = dict(
+    r_max = 200 ) # Max R for initial quality cuts
+
+nS1_eff_min     = 0.80  # Min nS1==1 eff. to continue map production.
+nS1_eff_max     = 1.00  # Max nS1==1 eff. to continue map production.
+
+nS2_eff_min     = 0.90 # Min nS2==1 eff. to continue map production.
+nS2_eff_max     = 1.00 # Max nS2==1 eff. to continue map production.
+
+nsigmas_Zdst    = 10   # Number of sigmas to consider Z dst correct.
+
+n_dev_rate      = 5    # Number of rel. dev. to consider rate dst correct.
+
+band_sel_params = dict(
+    range_Z     = (10, 550)      ,  # Z range to apply selection.
+    range_E     = (10.0e+3,14e+3),  # Energy range to apply sel.
+    nbins_z     = 50             ,  # Number of bins in Z axis.
+    nbins_e     = 50             ,  # Number of bins in energy axis.
+    nsigma_sel  = 3.5            ,  # Number of sigmas to apply sel.
+    eff_min     = 0.90           ,  # Min eff. to continue map prod.
+    eff_max     = 1.00           )  # Max eff. to continue map prod.
+
+# get automatic binning
+thr_evts_for_sel_map_bins = 1e6    # Threshold to use 50 or 100 bins.
+default_n_bins            = None   # If not specified: n_bins=50 or 100.
+
+### Histograms params
+ns1_histo_params  = dict(
+    nbins_hist    = 10    ,
+    range_hist    = (0,10),
+    norm          = True  )
+
+ns2_histo_params  = dict(
+    nbins_hist    = 10    ,
+    range_hist    = (0,10),
+    norm          = True  )
+
+rate_histo_params = dict(
+    bin_size      = 180  ,
+    normed        = False)
+
+## Map parameters
+map_params        = dict(
+    nbins_z       = 15            ,
+    nbins_e       = 25            ,
+    z_range       = (10, 550)     ,
+    e_range       = (2000, 18000) ,
+    chi2_range    = (0,10)        ,
+    lt_range      = (1000, 15000) ,
+    nmin          = 100           ,
+    maxFailed     = 600           ,
+    r_max         = 200           ,
+    r_fid         = 100           ,
+    nStimeprofile = 1800          ,
+    x_range       = (-200,200)    ,
+    y_range       = (-200,200)    )

--- a/krcal/map_builder/config_NoChecks.conf
+++ b/krcal/map_builder/config_NoChecks.conf
@@ -1,0 +1,72 @@
+folder             = '{folderin}'
+file_in            = '{filein}'
+file_bootstrap_map = '$ICDIR/database/test_data/kr_emap_xy_100_100_r_6573_time.h5'
+file_out_map       = '{fileoutmap}'
+file_out_hists     = '{fileouthist}'
+
+# High Energy Configuration File:
+ref_Z_histogram    = dict(
+    ref_histo_file = '$ICARO/krcal/map_builder/reference_files/z_dst_HE_mean_ref.h5',
+    key_Z_histo    = 'histo_Z_dst'                                                  )
+
+# run number 0 is for MC
+run_number = '{runnumber}'
+
+# event selector control
+
+quality_ranges  = dict(
+    r_max = 200 ) # Max R for initial quality cuts
+
+nS1_eff_min     = 0.  # Min nS1==1 eff. to continue map production.
+nS1_eff_max     = 1.  # Max nS1==1 eff. to continue map production.
+
+nS2_eff_min     = 0. # Min nS2==1 eff. to continue map production.
+nS2_eff_max     = 1. # Max nS2==1 eff. to continue map production.
+
+nsigmas_Zdst    = 1e6   # Number of sigmas to consider Z dst correct.
+
+n_dev_rate      = 1e6    # Number of rel. dev. to consider rate dst correct.
+
+band_sel_params = dict(
+    range_Z     = (10, 550)      ,  # Z range to apply selection.
+    range_E     = (10.0e+3,14e+3),  # Energy range to apply sel.
+    nbins_z     = 50             ,  # Number of bins in Z axis.
+    nbins_e     = 50             ,  # Number of bins in energy axis.
+    nsigma_sel  = 3.5            ,  # Number of sigmas to apply sel.
+    eff_min     = 0.             ,  # Min eff. to continue map prod.
+    eff_max     = 1.             )  # Max eff. to continue map prod.
+
+# get automatic binning
+thr_evts_for_sel_map_bins = 1e6    # Threshold to use 50 or 100 bins.
+default_n_bins            = None   # If not specified: n_bins=50 or 100.
+
+### Histograms params
+ns1_histo_params  = dict(
+    nbins_hist    = 10    ,
+    range_hist    = (0,10),
+    norm          = True  )
+
+ns2_histo_params  = dict(
+    nbins_hist    = 10    ,
+    range_hist    = (0,10),
+    norm          = True  )
+
+rate_histo_params = dict(
+    bin_size      = 180  ,
+    normed        = False)
+
+## Map parameters
+map_params        = dict(
+    nbins_z       = 15            ,
+    nbins_e       = 25            ,
+    z_range       = (10, 550)     ,
+    e_range       = (2000, 18000) ,
+    chi2_range    = (0,10)        ,
+    lt_range      = (1000, 15000) ,
+    nmin          = 100           ,
+    maxFailed     = 600           ,
+    r_max         = 200           ,
+    r_fid         = 100           ,
+    nStimeprofile = 1800          ,
+    x_range       = (-200,200)    ,
+    y_range       = (-200,200)    )

--- a/krcal/map_builder/map_builder_functions_test.py
+++ b/krcal/map_builder/map_builder_functions_test.py
@@ -39,12 +39,14 @@ def test_scrip_runs_and_produces_correct_outputs(folder_test_dst  ,
     map_file_out   = os.path.join(output_maps_tmdir, 'test_out_map.h5')
     histo_file_out = os.path.join(output_maps_tmdir, 'test_out_histo.h5')
     default_n_bins = 15
+    run_number     = 7517
     config = configure('maps $ICARO/krcal/map_builder/config_LBphys.conf'.split())
     config.update(dict(folder         = folder_test_dst,
                        file_in        = test_dst_file  ,
                        file_out_map   = map_file_out   ,
                        file_out_hists = histo_file_out ,
-                       default_n_bins = default_n_bins ))
+                       default_n_bins = default_n_bins ,
+                       run_number     = run_number     ))
     map_builder(config.as_namespace)
     maps = read_maps(map_file_out)
     assert type(maps)==ASectorMap
@@ -92,12 +94,14 @@ def test_exception_s1(folder_test_dst, test_dst_file, output_maps_tmdir):
     histo_file_out = os.path.join(output_maps_tmdir, 'test_out_histo_s1.h5')
     min_eff_test = 0.
     max_eff_test = 0.8
+    run_number   = 7517
     conf.update(dict(folder         = folder_test_dst,
                      file_in        = test_dst_file  ,
                      file_out_map   = map_file_out   ,
                      file_out_hists = histo_file_out ,
                      nS1_eff_min    = min_eff_test   ,
-                     nS1_eff_max    = max_eff_test   ))
+                     nS1_eff_max    = max_eff_test   ,
+                     run_number     = run_number     ))
 
     assert_raises(AbortingMapCreation,
                   map_builder        ,
@@ -112,12 +116,14 @@ def test_exception_s2(folder_test_dst, test_dst_file, output_maps_tmdir):
     histo_file_out = os.path.join(output_maps_tmdir, 'test_out_histo_s2.h5')
     min_eff_test = 0.
     max_eff_test = 0.9
+    run_number   = 7517
     conf.update(dict(folder         = folder_test_dst,
                      file_in        = test_dst_file  ,
                      file_out_map   = map_file_out   ,
                      file_out_hists = histo_file_out ,
                      nS2_eff_min    = min_eff_test   ,
-                     nS2_eff_max    = max_eff_test   ))
+                     nS2_eff_max    = max_eff_test   ,
+                     run_number     = run_number     ))
 
     assert_raises(AbortingMapCreation,
                   map_builder        ,
@@ -131,11 +137,13 @@ def test_exception_rate(folder_test_dst, test_dst_file, output_maps_tmdir):
     map_file_out   = os.path.join(output_maps_tmdir, 'test_out_map_rate.h5'  )
     histo_file_out = os.path.join(output_maps_tmdir, 'test_out_histo_rate.h5')
     n_dev_rate = 0.5
+    run_number   = 7517
     conf.update(dict(folder         = folder_test_dst,
                      file_in        = test_dst_file  ,
                      file_out_map   = map_file_out   ,
                      file_out_hists = histo_file_out ,
-                     n_dev_rate     = n_dev_rate     ))
+                     n_dev_rate     = n_dev_rate     ,
+                     run_number     = run_number     ))
 
     assert_raises(AbortingMapCreation,
                   map_builder        ,
@@ -150,11 +158,13 @@ def test_exception_Zdst(folder_test_dst, test_dst_file, output_maps_tmdir):
     map_file_out   = os.path.join(output_maps_tmdir, 'test_out_map_Z.h5'  )
     histo_file_out = os.path.join(output_maps_tmdir, 'test_out_histo_Z.h5')
     nsigmas_Zdst = 0.5
+    run_number   = 7517
     conf.update(dict(folder         = folder_test_dst,
                      file_in        = test_dst_file  ,
                      file_out_map   = map_file_out   ,
                      file_out_hists = histo_file_out ,
-                     nsigmas_Zdst   = nsigmas_Zdst   ))
+                     nsigmas_Zdst   = nsigmas_Zdst   ,
+                     run_number     = run_number     ))
 
     assert_raises(AbortingMapCreation,
                   map_builder        ,
@@ -171,11 +181,13 @@ def test_exception_bandsel(folder_test_dst, test_dst_file, output_maps_tmdir):
     band_sel_params_new = copy.copy(conf.as_namespace.band_sel_params)
     band_sel_params_new['eff_min'] = 0.
     band_sel_params_new['eff_max'] = 0.89
+    run_number = 7517
     conf.update(dict(folder         = folder_test_dst,
                      file_in        = test_dst_file  ,
                      file_out_map   = map_file_out   ,
                      file_out_hists = histo_file_out ,
-                     band_sel_params = band_sel_params_new))
+                     band_sel_params = band_sel_params_new,
+                     run_number     = run_number     ))
     assert_raises(AbortingMapCreation,
                   map_builder        ,
                   conf.as_namespace  )

--- a/krcal/map_builder/reference_files/z_dst_HE_HKr_mean_ref.h5
+++ b/krcal/map_builder/reference_files/z_dst_HE_HKr_mean_ref.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e48d98f30d6655f3793964dcf7d469f9de3f9c16b27370437789d9dc982283a3
+size 53240

--- a/krcal/map_builder/reference_files/z_dst_LB_run4_mean_ref.h5
+++ b/krcal/map_builder/reference_files/z_dst_LB_run4_mean_ref.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1bf1895f9912e406e8578896ffb8667e0d7984ae64e04d6bfb71130b5d162189
+size 53233


### PR DESCRIPTION
This PR adds two new configuration files. One of them corresponds to the case that no checks are required. On the other hand, the other file will be used for high energy calibration runs with a high krypton rate. Reference histograms file is also added for this last case.