### PR TITLE
Change LB config files to use same binning

### DIFF
--- a/krcal/map_builder/config_LBphys.conf
+++ b/krcal/map_builder/config_LBphys.conf
@@ -38,7 +38,7 @@ band_sel_params = dict(
 
 # get automatic binning
 thr_evts_for_sel_map_bins = 1e6    # Threshold to use 50 or 100 bins.
-default_n_bins            = None   # If not specified: n_bins=50 or 100.
+default_n_bins            = 50     # If not specified: n_bins=50 or 100.
 
 ### Histograms params
 ns1_histo_params  = dict(
@@ -61,9 +61,9 @@ map_params        = dict(
     nbins_e       = 25            ,
     z_range       = (10, 550)     ,
     e_range       = (2000, 18000) ,
-    chi2_range    = (0,10)        ,
+    chi2_range    = (0,10000)     ,
     lt_range      = (1000, 15000) ,
-    nmin          = 100           ,
+    nmin          = 50            ,
     maxFailed     = 600           ,
     r_max         = 200           ,
     r_fid         = 100           ,

--- a/krcal/map_builder/config_LBphys_run4.conf
+++ b/krcal/map_builder/config_LBphys_run4.conf
@@ -38,7 +38,7 @@ band_sel_params = dict(
 
 # get automatic binning
 thr_evts_for_sel_map_bins = 1e6    # Threshold to use 50 or 100 bins.
-default_n_bins            = None   # If not specified: n_bins=50 or 100.
+default_n_bins            = 50     # If not specified: n_bins=50 or 100.
 
 ### Histograms params
 ns1_histo_params  = dict(
@@ -61,9 +61,9 @@ map_params        = dict(
     nbins_e       = 25            ,
     z_range       = (10, 550)     ,
     e_range       = (2000, 18000) ,
-    chi2_range    = (0,10)        ,
+    chi2_range    = (0,10000)     ,
     lt_range      = (1000, 15000) ,
-    nmin          = 100           ,
+    nmin          = 50            ,
     maxFailed     = 600           ,
     r_max         = 200           ,
     r_fid         = 100           ,

--- a/krcal/map_builder/map_builder_functions_test.py
+++ b/krcal/map_builder/map_builder_functions_test.py
@@ -41,12 +41,15 @@ def test_scrip_runs_and_produces_correct_outputs(folder_test_dst  ,
     default_n_bins = 15
     run_number     = 7517
     config = configure('maps $ICARO/krcal/map_builder/config_LBphys.conf'.split())
+    map_params_new = copy.copy(config.as_namespace.map_params)
+    map_params_new['nmin'] = 100
     config.update(dict(folder         = folder_test_dst,
                        file_in        = test_dst_file  ,
                        file_out_map   = map_file_out   ,
                        file_out_hists = histo_file_out ,
                        default_n_bins = default_n_bins ,
-                       run_number     = run_number     ))
+                       run_number     = run_number     ,
+                       map_params     = map_params_new ))
     map_builder(config.as_namespace)
     maps = read_maps(map_file_out)
     assert type(maps)==ASectorMap


### PR DESCRIPTION
The purpose of this PR is to change Low Background configuration files to build always 50x50 maps. To do that, ``nmin`` parameter is modified. Besides that, chi2 range has also been changed according to new definition.