### PR TITLE
Add small number to time_range right limit in get_time_series

### DIFF
--- a/krcal/core/selection_functions.py
+++ b/krcal/core/selection_functions.py
@@ -90,7 +90,9 @@ def get_time_series_df(time_bins    : Number,
             List[np.array] : This are the list of masks defining the events in the time series.
 
     """
-    ip = np.linspace(time_range[0], time_range[-1], time_bins+1)
+    #Add small number to right edge to be included with in_range function
+    eps = 1e-12
+    ip = np.linspace(time_range[0], time_range[-1] + eps, time_bins+1)
     masks = np.array([in_range(dst[time_column].values, ip[i], ip[i + 1]) for i in range(len(ip) -1)])
     return shift_to_bin_centers(ip), masks
 

--- a/krcal/core/selection_functions.py
+++ b/krcal/core/selection_functions.py
@@ -91,8 +91,8 @@ def get_time_series_df(time_bins    : Number,
 
     """
     #Add small number to right edge to be included with in_range function
-    eps = 1e-12
-    ip = np.linspace(time_range[0], time_range[-1] + eps, time_bins+1)
+    modified_right_limit = np.nextafter(time_range[-1], np.inf)
+    ip = np.linspace(time_range[0], modified_right_limit, time_bins+1)
     masks = np.array([in_range(dst[time_column].values, ip[i], ip[i + 1]) for i in range(len(ip) -1)])
     return shift_to_bin_centers(ip), masks
 

--- a/test_data/maps/test_map_nan.h5
+++ b/test_data/maps/test_map_nan.h5
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b6ae5ebcd3dbf60efd37c0d4e35506dac99c8b879822fc04911c1a520780a2de
-size 36896
+oid sha256:3f811779717ed4d5ff53ea793019c4bee30ccee93bf5512b619661d503efc01c
+size 42600


### PR DESCRIPTION
This PR adds  1e-12 to the right limit of get_time_series_df function, since the right limit is not included in in_range function. This is relevant for MC  where all events have time 0  so with `in_range(0,0)` no event is selected. 