### PR TITLE
Change fit_map_xy_df function to allow using an unsorted dst

### DIFF
--- a/krcal/core/fitmap_functions.py
+++ b/krcal/core/fitmap_functions.py
@@ -179,8 +179,8 @@ def fit_map_xy_df(selection_map : Dict[int, List[DataFrame]],
         i = xybin[0]
         j = xybin[1]
         nevt = event_map[i][j]
-        tlast = time_diffs[-1]
-        tfrst = time_diffs[0]
+        tlast = time_diffs.max()
+        tfrst = time_diffs.min()
         ts, masks =  get_time_series_df(n_time_bins, (tfrst, tlast), selection_map[i][j])
 
         logging.debug(f' ****fit_fcs_in_xy_bin: bins ={i,j}')

--- a/krcal/map_builder/map_builder_functions.py
+++ b/krcal/map_builder/map_builder_functions.py
@@ -106,6 +106,7 @@ def load_data(input_path         : str ,
     input_path = os.path.expandvars(input_path)
     dst_files = glob.glob(input_path + input_dsts)
     dst_full  = load_dsts(dst_files, "DST", "Events")
+    dst_full  = dst_full.sort_values(by=['time'])
     mask_quality = quality_cut(dst_full, **quality_ranges)
     dst_filtered = dst_full[mask_quality]
 

--- a/krcal/map_builder/map_builder_functions_test.py
+++ b/krcal/map_builder/map_builder_functions_test.py
@@ -1,6 +1,6 @@
 import os
 import copy
-import numpy as np
+import numpy  as np
 import tables as tb
 from pytest        import mark
 from numpy.testing import assert_raises


### PR DESCRIPTION
This is a minimal change, but necessary, since computation of the time intervals (``fit_map_xy_df`` in ``fitmap_functions.py``) was incorrect when using an unsorted kdst for making the map.