### PR TITLE
Add cut evolution

### DIFF
--- a/krcal/core/io_functions.py
+++ b/krcal/core/io_functions.py
@@ -23,7 +23,7 @@ def compute_and_save_hist_as_pd(values     : np.array           ,
                                 hist_name  : str                ,
                                 n_bins     : int                ,
                                 range_hist : Tuple[float, float],
-                                norm       : bool               )->None:
+                                norm       : bool = False       )->None:
     """
     Computes 1d-histogram and saves it in a file.
     The name of the table inside the file must be provided.

--- a/krcal/core/kr_parevol_functions.py
+++ b/krcal/core/kr_parevol_functions.py
@@ -3,7 +3,7 @@ from . correction_functions import e0_xy_correction
 from . fit_functions        import compute_drift_v
 from . fit_functions        import quick_gauss_fit
 from . kr_types             import ASectorMap
-from .kr_types              import masks_container
+from . kr_types             import masks_container
 
 
 from invisible_cities.reco .corrections_new import apply_all_correction
@@ -248,10 +248,10 @@ def cut_time_evolution(masks_time : List[np.array],
     """
 
     len_ts = len(masks_time)
-    n0    = np.zeros(len_ts)
-    nS1   = np.zeros(len_ts)
-    nS2   = np.zeros(len_ts)
-    nBand = np.zeros(len_ts)
+    n0     = np.zeros(len_ts)
+    nS1    = np.zeros(len_ts)
+    nS2    = np.zeros(len_ts)
+    nBand  = np.zeros(len_ts)
     for index in range(len_ts):
         t_mask       = masks_time[index]
         n0   [index] = dst[t_mask].event.nunique()

--- a/krcal/core/kr_parevol_functions.py
+++ b/krcal/core/kr_parevol_functions.py
@@ -149,7 +149,7 @@ def computing_kr_parameters(data       : pd.DataFrame,
 
 
 def kr_time_evolution(ts         : np.array,
-                      masks      : List[np.array],
+                      masks_time : List[np.array],
                       dst        : pd.DataFrame,
                       emaps      : ASectorMap,
                       xr_map     : Tuple[float, float],
@@ -171,7 +171,7 @@ def kr_time_evolution(ts         : np.array,
     ----------
     ts: np.array of floats
         Sequence of central times for the different time slices.
-    masks: list of boolean lists
+    masks_time: list of boolean lists
         Allows dividing the distribution into time slices.
     data: DataFrame
         Kdst distribution to analyze.
@@ -205,8 +205,8 @@ def kr_time_evolution(ts         : np.array,
     """
 
     frames = []
-    for index in range(len(masks)):
-        sel_dst = dst[masks[index]]
+    for index in range(len(masks_time)):
+        sel_dst = dst[masks_time[index]]
         pars    = computing_kr_parameters(sel_dst, ts[index],
                                           emaps,
                                           zslices_lt, zrange_lt,

--- a/krcal/core/kr_parevol_functions.py
+++ b/krcal/core/kr_parevol_functions.py
@@ -3,6 +3,8 @@ from . correction_functions import e0_xy_correction
 from . fit_functions        import compute_drift_v
 from . fit_functions        import quick_gauss_fit
 from . kr_types             import ASectorMap
+from .kr_types              import masks_container
+
 
 from invisible_cities.reco .corrections_new import apply_all_correction
 from invisible_cities.reco .corrections_new import norm_strategy
@@ -215,3 +217,52 @@ def kr_time_evolution(ts         : np.array,
     total_pars = pd.concat(frames, ignore_index=True)
 
     return total_pars
+
+def cut_time_evolution(masks_time : List[np.array],
+                       dst        : pd.DataFrame,
+                       masks_cuts : masks_container,
+                       pars_table : pd.DataFrame):
+
+    """
+    Computes the efficiency evolution in time for a given krypton distribution
+    for different time slices.
+    Returns the input DataFrame updated with new 3 columns.
+
+    Parameters
+    ----------
+    masks: list of boolean lists
+        Allows dividing the distribution into time slices.
+    data: DataFrame
+        Kdst distribution to analyze.
+    masks_cuts: masks_container
+        Container for the S1, S2 and Band cuts masks.
+        The masks don't have to be inclusive.
+    pars: DataFrame
+        Each column corresponds to the average value for a given parameter.
+        Each row corresponds to the parameters for a given time slice.
+
+    Returns
+    -------
+    parspars_table_out: DataFrame
+        pars Table imput updated with 3 new columns, one for each cut.
+    """
+
+    len_ts = len(masks_time)
+    n0    = np.zeros(len_ts)
+    nS1   = np.zeros(len_ts)
+    nS2   = np.zeros(len_ts)
+    nBand = np.zeros(len_ts)
+    for index in range(len_ts):
+        t_mask       = masks_time[index]
+        n0   [index] = dst[t_mask].event.nunique()
+        nS1mask      = t_mask  & masks_cuts.s1
+        nS1  [index] = dst[nS1mask].event.nunique()
+        nS2mask      = nS1mask & masks_cuts.s2
+        nS2  [index] = dst[nS2mask].event.nunique()
+        nBandmask    = nS2mask & masks_cuts.band
+        nBand[index] = dst[nBandmask].event.nunique()
+
+    pars_table_out = pars_table.assign(S1eff   = nS1   / n0,
+                                       S2eff   = nS2   / nS1,
+                                       Bandeff = nBand / nS2)
+    return pars_table_out

--- a/krcal/core/kr_parevol_functions_test.py
+++ b/krcal/core/kr_parevol_functions_test.py
@@ -1,0 +1,68 @@
+import glob
+import numpy  as np
+import pandas as pd
+
+from numpy.testing              import assert_allclose
+from flaky                      import flaky
+
+from . kr_parevol_functions     import cut_time_evolution
+from . selection_functions      import get_time_series_df
+from . kr_types                 import masks_container
+
+from invisible_cities.io  .dst_io        import load_dst
+from invisible_cities.core.testing_utils import assert_dataframes_close
+
+
+
+def test_cut_time_evolution_different_cuts(folder_test_dst,
+                                           test_dst_file ):
+
+    dst                = load_dst(folder_test_dst + test_dst_file, "DST", "Events")
+    dst                = dst.drop_duplicates('event')
+    mask_S1            = np.random.choice([True, False], len(dst    ))
+    mask_S2            = np.zeros_like(mask_S1, dtype=bool)
+    mask_band          = np.zeros_like(mask_S1, dtype=bool)
+    mask_S2[mask_S1]   = np.random.choice([True, False], sum(mask_S1))
+    mask_band[mask_S2] = np.random.choice([True, False], sum(mask_S2))
+    mask_cut           = masks_container(s1   = mask_S1,
+                                         s2   = mask_S2,
+                                         band = mask_band)
+    min_time           = dst.time.min()
+    max_time           = dst.time.max()
+    ts, masks_time     = get_time_series_df(time_bins  = 1,
+                                            time_range = (min_time, max_time),
+                                            dst        = dst)
+    pars               = pd.DataFrame({'ts':ts})
+    pars_out           = cut_time_evolution(masks_time, dst, mask_cut, pars)
+    pars_expected      = pd.DataFrame({'ts':ts, 'S1eff':0.5, 'S2eff':0.5, 'Bandeff':0.5})
+    assert_dataframes_close(pars_expected, pars_out, atol=5e-2)
+
+def test_cut_time_evolution_different_time_bins(folder_test_dst,
+                                                test_dst_file ):
+    dst                    = load_dst(folder_test_dst+test_dst_file, "DST", "Events")
+    dst                    = dst.drop_duplicates('event')
+    min_time               = dst.time.min()
+    max_time               = dst.time.max()
+    ts, masks_time         = get_time_series_df(time_bins  = 3,
+                                                time_range = (min_time, max_time),
+                                                dst        = dst)
+    #set different probability of passing for different time bins, only for first mask
+    probs_s1               = [0.9, 0.5, 0.1]
+
+    mask_s1                = np.zeros(len(dst), dtype=bool)
+    mask_s1[masks_time[0]] = np.random.choice([True, False], sum(masks_time[0]), p=(probs_s1[0], 1-probs_s1[0]))
+    mask_s1[masks_time[1]] = np.random.choice([True, False], sum(masks_time[1]), p=(probs_s1[1], 1-probs_s1[1]))
+    mask_s1[masks_time[2]] = np.random.choice([True, False], sum(masks_time[2]), p=(probs_s1[2], 1-probs_s1[2]))
+
+    mask_cut               = masks_container(s1   = mask_s1,
+                                             s2   = mask_s1,
+                                             band = mask_s1)
+    #the expected relative efficiencies for other cuts are 1 since the mask is repeated
+    pars_expected          = pd.DataFrame({'ts':ts,
+                                           'S1eff' : probs_s1,
+                                           'S2eff': [1.]*3,
+                                           'Bandeff':[1.]*3})
+    pars                   = pd.DataFrame({'ts'   : ts})
+    pars_out               = cut_time_evolution(masks_time, dst, mask_cut, pars)
+
+    assert_dataframes_close(pars_expected, pars_out, atol=5e-2)

--- a/krcal/core/kr_types.py
+++ b/krcal/core/kr_types.py
@@ -171,3 +171,9 @@ class FitMapValue:  # A ser of values of a FitMap
     lt    : float
     e0u   : float
     ltu   : float
+
+@dataclass
+class masks_container:
+    s1   : np.array
+    s2   : np.array
+    band : np.array

--- a/krcal/map_builder/map_builder_functions.py
+++ b/krcal/map_builder/map_builder_functions.py
@@ -20,6 +20,7 @@ from .. core.map_functions                 import add_mapinfo
 from .. core.correction_functions          import e0_xy_correction
 from .. core.selection_functions           import get_time_series_df
 from .. core.kr_parevol_functions          import kr_time_evolution
+from .. core.kr_parevol_functions          import cut_time_evolution
 from .. core.map_functions                 import amap_replace_nan_by_mean
 from .. core.map_functions                 import relative_errors
 from .. core.io_functions                  import write_complete_maps
@@ -534,10 +535,10 @@ def add_krevol(maps         : ASectorMap,
 
     ts, masks   = get_time_series_df(time_bins  = ntimebins,
                                      time_range = (min_time, max_time),
-                                     dst        = dstf)
-
+                                     dst        = dst)
+    masks_f     =  [mask[fmask] for mask in masks]
     pars        = kr_time_evolution(ts     = ts,
-                                    masks  = masks,
+                                    masks  = masks_f,
                                     dst    = dstf,
                                     emaps  = maps,
                                     xr_map = x_range,
@@ -545,13 +546,17 @@ def add_krevol(maps         : ASectorMap,
                                     nx_map = XYbins[0],
                                     ny_map = XYbins[1])
 
+    pars_ec     = cut_time_evolution(masks_time = masks,
+                                     dst        = dst,
+                                     masks_cuts = masks_cuts,
+                                     pars_table = pars)
     e0par       = np.array([pars['e0'].mean(), pars['e0'].var()**0.5])
     ltpar       = np.array([pars['lt'].mean(), pars['lt'].var()**0.5])
     print("    Mean core E0: {0:.1f}+-{1:.1f} pes".format(*e0par))
     print("    Mean core Lt: {0:.1f}+-{1:.1f} mus".format(*ltpar))
 
 
-    maps.t_evol = pars
+    maps.t_evol = pars_ec
 
     return
 

--- a/krcal/map_builder/map_builder_functions.py
+++ b/krcal/map_builder/map_builder_functions.py
@@ -13,22 +13,22 @@ from .. core.kr_types                      import masks_container
 from .. core.selection_functions           import selection_in_band
 from .. core.selection_functions           import select_xy_sectors_df
 from .. core.selection_functions           import event_map_df
+from .. core.selection_functions           import get_time_series_df
 from .. core.fitmap_functions              import fit_map_xy_df
 from .. core.map_functions                 import amap_from_tsmap
 from .. core.map_functions                 import tsmap_from_fmap
 from .. core.map_functions                 import add_mapinfo
-from .. core.correction_functions          import e0_xy_correction
-from .. core.selection_functions           import get_time_series_df
-from .. core.kr_parevol_functions          import kr_time_evolution
-from .. core.kr_parevol_functions          import cut_time_evolution
 from .. core.map_functions                 import amap_replace_nan_by_mean
 from .. core.map_functions                 import relative_errors
+from .. core.correction_functions          import e0_xy_correction
+from .. core.kr_parevol_functions          import kr_time_evolution
+from .. core.kr_parevol_functions          import cut_time_evolution
+from .. core.kr_parevol_functions          import get_number_of_time_bins
 from .. core.io_functions                  import write_complete_maps
 from .. core.io_functions                  import compute_and_save_hist_as_pd
 from .. core.histo_functions               import compute_similar_histo
 from .. core.histo_functions               import normalize_histo_and_poisson_error
 from .. core.histo_functions               import ref_hist
-from .. core.kr_parevol_functions          import get_number_of_time_bins
 
 from . checking_functions                  import check_if_values_in_interval
 from . checking_functions                  import check_failed_fits

--- a/krcal/map_builder/map_builder_functions.py
+++ b/krcal/map_builder/map_builder_functions.py
@@ -525,31 +525,34 @@ def add_krevol(maps         : ASectorMap,
     ---------
     Nothing
     """
-    fmask      = (dst.R < r_fid) & masks_cuts.s1 & masks_cuts.s2 & masks_cuts.band
-    dstf       = dst[fmask]
-    min_time   = dstf.time.min()
-    max_time   = dstf.time.max()
-    ntimebins  = get_number_of_time_bins(nStimeprofile = nStimeprofile,
-                                         tstart        = min_time,
-                                         tfinal        = max_time)
 
-    ts, masks   = get_time_series_df(time_bins  = ntimebins,
-                                     time_range = (min_time, max_time),
-                                     dst        = dst)
-    masks_f     =  [mask[fmask] for mask in masks]
-    pars        = kr_time_evolution(ts     = ts,
-                                    masks  = masks_f,
-                                    dst    = dstf,
-                                    emaps  = maps,
-                                    xr_map = x_range,
-                                    yr_map = y_range,
-                                    nx_map = XYbins[0],
-                                    ny_map = XYbins[1])
+    fmask     = (dst.R < r_fid) & masks_cuts.s1 & masks_cuts.s2 & masks_cuts.band
+    dstf      = dst[fmask]
+    min_time  = dstf.time.min()
+    max_time  = dstf.time.max()
+    ntimebins = get_number_of_time_bins(nStimeprofile = nStimeprofile,
+                                        tstart        = min_time,
+                                        tfinal        = max_time)
 
-    pars_ec     = cut_time_evolution(masks_time = masks,
-                                     dst        = dst,
-                                     masks_cuts = masks_cuts,
-                                     pars_table = pars)
+    ts, masks_time = get_time_series_df(time_bins  = ntimebins,
+                                        time_range = (min_time, max_time),
+                                        dst        = dst)
+
+    masks_timef    = [mask[fmask] for mask in masks_time]
+    pars           = kr_time_evolution(ts         = ts,
+                                       masks_time = masks_timef,
+                                       dst        = dstf,
+                                       emaps      = maps,
+                                       xr_map     = x_range,
+                                       yr_map     = y_range,
+                                       nx_map     = XYbins[0],
+                                       ny_map     = XYbins[1])
+
+    pars_ec        = cut_time_evolution(masks_time = masks_time,
+                                        dst        = dst,
+                                        masks_cuts = masks_cuts,
+                                        pars_table = pars)
+
     e0par       = np.array([pars['e0'].mean(), pars['e0'].var()**0.5])
     ltpar       = np.array([pars['lt'].mean(), pars['lt'].var()**0.5])
     print("    Mean core E0: {0:.1f}+-{1:.1f} pes".format(*e0par))

--- a/krcal/map_builder/map_builder_functions.py
+++ b/krcal/map_builder/map_builder_functions.py
@@ -1,12 +1,13 @@
 from typing      import Tuple
 from dataclasses import dataclass
 from copy        import deepcopy
+
 import pandas as pd
 import numpy  as np
 import glob
 import os
 
-from .. core.kr_types  import type_of_signal
+from .. core.kr_types                      import type_of_signal
 from .. core.kr_types                      import FitType
 from .. core.selection_functions           import selection_in_band
 from .. core.selection_functions           import select_xy_sectors_df
@@ -16,25 +17,20 @@ from .. core.map_functions                 import amap_from_tsmap
 from .. core.map_functions                 import tsmap_from_fmap
 from .. core.map_functions                 import add_mapinfo
 from .. core.correction_functions          import e0_xy_correction
-
 from .. core.selection_functions           import get_time_series_df
 from .. core.kr_parevol_functions          import kr_time_evolution
+from .. core.map_functions                 import amap_replace_nan_by_mean
+from .. core.map_functions                 import relative_errors
+from .. core.io_functions                  import write_complete_maps
+from .. core.io_functions                  import compute_and_save_hist_as_pd
+from .. core.histo_functions               import compute_similar_histo
+from .. core.histo_functions               import normalize_histo_and_poisson_error
+from .. core.histo_functions               import ref_hist
+from .. core.kr_parevol_functions          import get_number_of_time_bins
 
-
-from .. core.map_functions             import amap_replace_nan_by_mean
-from .. core.map_functions             import relative_errors
-
-
-from .. core       .io_functions       import write_complete_maps
-from .. core       .io_functions       import compute_and_save_hist_as_pd
-from .. core       .histo_functions    import compute_similar_histo
-from .. core       .histo_functions    import normalize_histo_and_poisson_error
-from .. core       .histo_functions    import ref_hist
-
-from .. core       .kr_parevol_functions import get_number_of_time_bins
-from . checking_functions import check_if_values_in_interval
-from . checking_functions import check_failed_fits
-from . checking_functions import get_core
+from . checking_functions                  import check_if_values_in_interval
+from . checking_functions                  import check_failed_fits
+from . checking_functions                  import get_core
 
 
 from invisible_cities.core.core_functions  import in_range
@@ -42,9 +38,6 @@ from invisible_cities.io  .dst_io          import load_dsts
 from invisible_cities.reco.corrections_new import ASectorMap
 from invisible_cities.reco.corrections_new import read_maps
 from invisible_cities.reco.corrections_new import norm_strategy
-
-from invisible_cities.icaro.hst_functions import measurement_string
-
 
 
 @dataclass
@@ -103,22 +96,22 @@ def load_data(input_path         : str ,
         To be completed
     """
 
-    input_path = os.path.expandvars(input_path)
-    dst_files = glob.glob(input_path + input_dsts)
-    dst_full  = load_dsts(dst_files, "DST", "Events")
-    dst_full  = dst_full.sort_values(by=['time'])
-    mask_quality = quality_cut(dst_full, **quality_ranges)
-    dst_filtered = dst_full[mask_quality]
+    input_path         = os.path.expandvars(input_path)
+    dst_files          = glob.glob(input_path + input_dsts)
+    dst_full           = load_dsts(dst_files, "DST", "Events")
+    dst_full           = dst_full.sort_values(by=['time'])
+    mask_quality       = quality_cut(dst_full, **quality_ranges)
+    dst_filtered       = dst_full[mask_quality]
 
     file_bootstrap_map = os.path.expandvars(file_bootstrap_map)
-    bootstrap_map = read_maps(file_bootstrap_map)
+    bootstrap_map      = read_maps(file_bootstrap_map)
 
-    ref_histo_file = os.path.expandvars(ref_histo_file)
-    z_pd       = pd.read_hdf(ref_histo_file, key=key_Z_histo)
-    z_histo    = ref_hist(bin_centres     = z_pd.bin_centres,
-                          bin_entries     = z_pd.bin_entries,
-                          err_bin_entries = z_pd.err_bin_entries)
-    ref_histos =  ref_hist_container(Z_dist_hist = z_histo)
+    ref_histo_file     = os.path.expandvars(ref_histo_file)
+    z_pd               = pd.read_hdf(ref_histo_file, key=key_Z_histo)
+    z_histo            = ref_hist(bin_centres     = z_pd.bin_centres,
+                                  bin_entries     = z_pd.bin_entries,
+                                  err_bin_entries = z_pd.err_bin_entries)
+    ref_histos         =  ref_hist_container(Z_dist_hist = z_histo)
 
     return dst_filtered, bootstrap_map, ref_histos
 
@@ -177,7 +170,7 @@ def selection_nS_mask_and_checking(dst        : pd.DataFrame                ,
                                 range_hist = range_hist,
                                 norm       = norm)
 
-    message = "Selection efficiency of "
+    message  = "Selection efficiency of "
     message += column.value
     message += "==1 ({0}) out of range ".format(np.round(eff, 3))
     message += "({0} - {1}).".format(interval[0], interval[1])
@@ -211,11 +204,11 @@ def check_Z_dst(Z_vect   : np.array     ,
     N_Z, err_N = normalize_histo_and_poisson_error(N = N_Z,
                                                    b = z_Z)
 
-    diff     = N_Z - ref_hist.bin_entries
-    diff_sig = diff / np.sqrt(err_N**2+ref_hist.err_bin_entries**2)
+    diff       = N_Z - ref_hist.bin_entries
+    diff_sig   = diff / np.sqrt(err_N**2+ref_hist.err_bin_entries**2)
 
-    message = "Z distribution very different to reference one. "
-    message += "At least 1 point out of {0} sigmas region. ".format(n_sigmas)
+    message    = "Z distribution very different to reference one. "
+    message   += "At least 1 point out of {0} sigmas region. ".format(n_sigmas)
     check_if_values_in_interval(values          = diff_sig ,
                                 low_lim         = -n_sigmas,
                                 up_lim          = n_sigmas ,
@@ -266,13 +259,13 @@ def check_rate_and_hist(times      : np.array           ,
                                              max_time) ,
                                 norm      = normed     )
 
-    n, _ = np.histogram(times, bins=ntimebins,
-                        range = (min_time, max_time))
-    mean    = np.mean(n)
-    dev     = np.std(n, ddof = 1)
-    rel_dev = dev / mean * 100
+    n, _     = np.histogram(times, bins=ntimebins,
+                            range = (min_time, max_time))
+    mean     = np.mean(n)
+    dev      = np.std(n, ddof = 1)
+    rel_dev  = dev / mean * 100
 
-    message = "Relative deviation ({0}) greater ".format(rel_dev)
+    message  = "Relative deviation ({0}) greater ".format(rel_dev)
     message += "than the allowed one ({0}).".format(n_dev)
     check_if_values_in_interval(values          = np.array(rel_dev),
                                 low_lim         = 0                ,
@@ -332,7 +325,8 @@ def band_selector_and_check(dst       : pd.DataFrame,
     else: pass;
 
     emaps = e0_xy_correction(boot_map, norm_strat  = norm_strat)
-    E0 = dst[input_mask].S2e.values * emaps(dst[input_mask].X.values, dst[input_mask].Y.values)
+    E0    = dst[input_mask].S2e.values * emaps(dst[input_mask].X.values,
+                                               dst[input_mask].Y.values)
 
     sel_krband = np.zeros_like(input_mask)
     sel_krband[input_mask], _, _, _, _ = selection_in_band(dst[input_mask].Z,
@@ -343,8 +337,8 @@ def band_selector_and_check(dst       : pd.DataFrame,
                                                            nbins_e = nbins_e,
                                                            nsigma  = nsigma_sel)
 
-    effsel = dst[sel_krband].event.nunique()/dst[input_mask].event.nunique()
-    message = "Band selection efficiency {0} ".format(np.round(effsel, 3))
+    effsel   = dst[sel_krband].event.nunique()/dst[input_mask].event.nunique()
+    message  = "Band selection efficiency {0} ".format(np.round(effsel, 3))
     message += "out of range: ({0} - {1}).".format(eff_min, eff_max)
     check_if_values_in_interval(values          = np.array(effsel),
                                 low_lim         = eff_min         ,
@@ -410,26 +404,26 @@ def calculate_map(dst     : pd.DataFrame,
     """
     xbins = np.linspace(*x_range, XYbins[0]+1)
     ybins = np.linspace(*y_range, XYbins[1]+1)
-    KXY = select_xy_sectors_df(dst, xbins, ybins)
-    nXY = event_map_df(KXY)
-    fmxy = fit_map_xy_df(selection_map = KXY,
-                         event_map     = nXY,
-                         n_time_bins   = 1,
-                         time_diffs    = dst.time.values,
-                         nbins_z       = nbins_z,
-                         nbins_e       = nbins_e,
-                         range_z       = z_range,
-                         range_e       = e_range,
-                         energy        = 'S2e',
-                         z             = 'Z',
-                         fit           = fit_type,
-                         n_min         = nmin)
-    tsm = tsmap_from_fmap(fmxy)
-    am  = amap_from_tsmap(tsm,
-                          ts         = 0,
-                          range_e    = e_range,
-                          range_chi2 = chi2_range,
-                          range_lt   = lt_range)
+    KXY   = select_xy_sectors_df(dst, xbins, ybins)
+    nXY   = event_map_df(KXY)
+    fmxy  = fit_map_xy_df(selection_map = KXY,
+                          event_map     = nXY,
+                          n_time_bins   = 1,
+                          time_diffs    = dst.time.values,
+                          nbins_z       = nbins_z,
+                          nbins_e       = nbins_e,
+                          range_z       = z_range,
+                          range_e       = e_range,
+                          energy        = 'S2e',
+                          z             = 'Z',
+                          fit           = fit_type,
+                          n_min         = nmin)
+    tsm   = tsmap_from_fmap(fmxy)
+    am    = amap_from_tsmap(tsm,
+                            ts         = 0,
+                            range_e    = e_range,
+                            range_chi2 = chi2_range,
+                            range_lt   = lt_range)
 
     return am
 
@@ -470,15 +464,15 @@ def regularize_map(maps : ASectorMap, x2range : Tuple[float, float] = (0, 2) ):
     amap: ASectorMap
         Regularized map
     """
-    amap     = deepcopy(maps)
-    outliers = np.logical_not(find_outliers(amap, x2range))
+    amap               = deepcopy(maps)
+    outliers           = np.logical_not(find_outliers(amap, x2range))
 
     amap.lt [outliers] = np.nan
     amap.ltu[outliers] = np.nan
     amap.e0 [outliers] = np.nan
     amap.e0u[outliers] = np.nan
-    asm  = relative_errors(amap)
-    amap = amap_replace_nan_by_mean(asm)
+    asm                = relative_errors(amap)
+    amap               = amap_replace_nan_by_mean(asm)
 
     return amap
 
@@ -534,21 +528,21 @@ def add_krevol(maps         : ASectorMap,
                                          tstart        = min_time,
                                          tfinal        = max_time)
 
-    ts, masks = get_time_series_df(time_bins  = ntimebins,
-                                   time_range = (min_time, max_time),
-                                   dst        = dstf)
+    ts, masks   = get_time_series_df(time_bins  = ntimebins,
+                                     time_range = (min_time, max_time),
+                                     dst        = dstf)
 
-    pars = kr_time_evolution(ts     = ts,
-                             masks  = masks,
-                             dst    = dstf,
-                             emaps  = maps,
-                             xr_map = x_range,
-                             yr_map = y_range,
-                             nx_map = XYbins[0],
-                             ny_map = XYbins[1])
+    pars        = kr_time_evolution(ts     = ts,
+                                    masks  = masks,
+                                    dst    = dstf,
+                                    emaps  = maps,
+                                    xr_map = x_range,
+                                    yr_map = y_range,
+                                    nx_map = XYbins[0],
+                                    ny_map = XYbins[1])
 
-    e0par    = np.array([pars['e0'].mean(), pars['e0'].var()**0.5])
-    ltpar    = np.array([pars['lt'].mean(), pars['lt'].var()**0.5])
+    e0par       = np.array([pars['e0'].mean(), pars['e0'].var()**0.5])
+    ltpar       = np.array([pars['lt'].mean(), pars['lt'].var()**0.5])
     print("    Mean core E0: {0:.1f}+-{1:.1f} pes".format(*e0par))
     print("    Mean core Lt: {0:.1f}+-{1:.1f} mus".format(*ltpar))
 
@@ -597,17 +591,17 @@ def compute_map(dst          : pd.DataFrame,
     regularized_maps = regularize_map(maps    = maps,
                                       x2range = chi2_range)
 
-    no_peripheral = remove_peripheral(regularized_maps,
-                                      XYbins[0]       ,
-                                      r_max           ,
-                                      r_max)
+    no_peripheral    = remove_peripheral(regularized_maps,
+                                         XYbins[0]       ,
+                                         r_max           ,
+                                         r_max)
 
-    no_peripheral = add_mapinfo(asm        = no_peripheral,
-                                xr         = x_range,
-                                yr         = y_range,
-                                nx         = XYbins[0],
-                                ny         = XYbins[1],
-                                run_number = int(run_number))
+    no_peripheral    = add_mapinfo(asm        = no_peripheral,
+                                   xr         = x_range,
+                                   yr         = y_range,
+                                   nx         = XYbins[0],
+                                   ny         = XYbins[1],
+                                   run_number = int(run_number))
 
     add_krevol(maps          = no_peripheral,
                dst           = dst,
@@ -639,7 +633,7 @@ def apply_cuts(dst              : pd.DataFrame       ,
                                            interval = nS1_eff_interval,
                                            output_f = store_hist_s1   ,
                                            **ns1_histo_params         )
-    nS1 = dst[mask1].event.nunique()
+    nS1   = dst[mask1].event.nunique()
     print("    1 S1 cut efficiency within the expectations ({0:2.2f}%)".format(nS1/n0*100))
     mask2 = selection_nS_mask_and_checking(dst = dst                  ,
                                            column = S2_signal         ,
@@ -647,7 +641,7 @@ def apply_cuts(dst              : pd.DataFrame       ,
                                            output_f = store_hist_s2   ,
                                            input_mask = mask1         ,
                                            **ns2_histo_params         )
-    nS2 = dst[mask2].event.nunique()
+    nS2   = dst[mask2].event.nunique()
     print("    1 S2 cut efficiency within the expectations ({0:2.2f}%)".format(nS2/nS1*100))
     check_Z_dst(Z_vect   = dst[mask2].Z,
                 ref_hist = ref_Z_histo ,
@@ -657,17 +651,18 @@ def apply_cuts(dst              : pd.DataFrame       ,
                                     boot_map   = bootstrapmap,
                                     input_mask = mask2       ,
                                     **band_sel_params        )
-    nZb = dst[mask3].event.nunique()
+    nZb   = dst[mask3].event.nunique()
     print("    Z band cut efficiency within the expectations ({0:2.2f}%)".format(nZb/nS2*100))
+
     return dst[mask3]
 
 def map_builder(config):
 
     print("Map builder starting...")
     print("Reading input files:")
-    print("    Input dst folder   : {}".format(config.folder))
-    print("    Input boostrap map : {}".format(config.file_bootstrap_map))
-    print("    Input histogram map: {}".format(config.ref_Z_histogram['ref_histo_file']))
+    print("    Input dst folder   : {}".format(config.folder))
+    print("    Input boostrap map : {}".format(config.file_bootstrap_map))
+    print("    Input histogram map: {}".format(config.ref_Z_histogram['ref_histo_file']))
 
 
     dst, bootstrapmap, ref_histos  = load_data(input_path         = config.folder            ,
@@ -722,11 +717,11 @@ def map_builder(config):
 
     print("    Number of bins: {0}x{0}".format(number_of_bins))
 
-    final_map = compute_map(dst        = dst_passed_cut   ,
-                            run_number = config.run_number,
-                            XYbins     = (number_of_bins  ,
-                                          number_of_bins) ,
-                            **config.map_params           )
+    final_map      = compute_map(dst        = dst_passed_cut   ,
+                                 run_number = config.run_number,
+                                 XYbins     = (number_of_bins  ,
+                                               number_of_bins) ,
+                                 **config.map_params           )
 
     write_complete_maps(asm      = final_map          ,
                         filename = config.file_out_map)

--- a/krcal/map_builder/map_builder_functions.py
+++ b/krcal/map_builder/map_builder_functions.py
@@ -9,6 +9,7 @@ import os
 
 from .. core.kr_types                      import type_of_signal
 from .. core.kr_types                      import FitType
+from .. core.kr_types                      import masks_container
 from .. core.selection_functions           import selection_in_band
 from .. core.selection_functions           import select_xy_sectors_df
 from .. core.selection_functions           import event_map_df
@@ -654,7 +655,10 @@ def apply_cuts(dst              : pd.DataFrame       ,
     nZb   = dst[mask3].event.nunique()
     print("    Z band cut efficiency within the expectations ({0:2.2f}%)".format(nZb/nS2*100))
 
-    return dst[mask3]
+    masks = masks_container(s1   = mask1,
+                            s2   = mask2,
+                            band = mask3)
+    return dst[mask3], masks
 
 def map_builder(config):
 
@@ -682,7 +686,7 @@ def map_builder(config):
                             n_dev      = config.n_dev_rate,
                             **config.rate_histo_params    )
 
-        dst_passed_cut = apply_cuts(dst              = dst                    ,
+        dst_passed_cut, masks = apply_cuts(dst       = dst                    ,
                                     S1_signal        = type_of_signal.nS1     ,
                                     nS1_eff_interval = (config.nS1_eff_min    ,
                                                         config.nS1_eff_max)   ,

--- a/krcal/map_builder/map_builder_functions_test.py
+++ b/krcal/map_builder/map_builder_functions_test.py
@@ -62,6 +62,31 @@ def test_scrip_runs_and_produces_correct_outputs(folder_test_dst  ,
     assert_dataframes_close(maps.lt , old_maps.lt , rtol=1e-5 )
     assert_dataframes_close(maps.ltu, old_maps.ltu, rtol=1e-5)
 
+@mark.dependency(depends="test_scrip_runs_and_produces_correct_outputs")
+def test_time_evol_table_correct_elements(output_maps_tmdir):
+    map_file_out = os.path.join(output_maps_tmdir, 'test_out_map.h5')
+    emaps        = read_maps(map_file_out)
+    time_table   = emaps.t_evol
+    columns      = time_table.columns
+    elements     =['ts'   ,
+                   'e0'   , 'e0u'   ,
+                   'lt'   , 'ltu'   ,
+                   'dv'   , 'dvu'   ,
+                   'resol', 'resolu',
+                   's1w'  , 's1wu'  ,
+                   's1h'  , 's1hu'  ,
+                   's1e'  , 's1eu'  ,
+                   's2w'  , 's2wu'  ,
+                   's2h'  , 's2hu'  ,
+                   's2e'  , 's2eu'  ,
+                   's2q'  , 's2qu'  ,
+                   'Nsipm', 'Nsipmu',
+                   'Xrms' , 'Xrmsu' ,
+                   'Yrms' , 'Yrmsu' ,
+                   'S1eff' , 'S2eff', 'Bandeff']
+    for element in elements:
+        assert element in columns
+
 @composite
 def xy_pos(draw, elements=floats(min_value=-200, max_value=200)):
     size = draw(integers(min_value=1, max_value=10))

--- a/krcal/map_builder/map_builder_functions_test.py
+++ b/krcal/map_builder/map_builder_functions_test.py
@@ -64,9 +64,9 @@ def test_scrip_runs_and_produces_correct_outputs(folder_test_dst  ,
     assert type(maps)==ASectorMap
 
     old_maps = read_maps(test_map_file)
-    assert_dataframes_close(maps.e0 , old_maps.e0 , rtol=1e-5 )
+    assert_dataframes_close(maps.e0 , old_maps.e0 , rtol=1e-5)
     assert_dataframes_close(maps.e0u, old_maps.e0u, rtol=1e-5)
-    assert_dataframes_close(maps.lt , old_maps.lt , rtol=1e-5 )
+    assert_dataframes_close(maps.lt , old_maps.lt , rtol=1e-5)
     assert_dataframes_close(maps.ltu, old_maps.ltu, rtol=1e-5)
 
 @mark.dependency(depends="test_scrip_runs_and_produces_correct_outputs")

--- a/krcal/map_builder/map_builder_functions_test.py
+++ b/krcal/map_builder/map_builder_functions_test.py
@@ -87,6 +87,14 @@ def test_time_evol_table_correct_elements(output_maps_tmdir):
     for element in elements:
         assert element in columns
 
+@mark.dependency(depends="test_scrip_runs_and_produces_correct_outputs")
+def test_time_evol_eff_less_one(output_maps_tmdir):
+    map_file_out = os.path.join(output_maps_tmdir, 'test_out_map.h5')
+    emaps        = read_maps(map_file_out)
+    assert np.all(emaps.t_evol.S1eff   <= 1.)
+    assert np.all(emaps.t_evol.S2eff   <= 1.)
+    assert np.all(emaps.t_evol.Bandeff <= 1.)
+
 @composite
 def xy_pos(draw, elements=floats(min_value=-200, max_value=200)):
     size = draw(integers(min_value=1, max_value=10))

--- a/test_data/maps/time_evol_table.h5
+++ b/test_data/maps/time_evol_table.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eee5dd986a3526a2a0c5948a9ef51f5316fc11a3c7c0f529f53499593cd73b54
+size 7040


### PR DESCRIPTION
This PR will add efficiencies for S1, S2 and band cuts to the time evolution table. It is meant to be backwards compatible so the old configs work.