### PR TITLE
Z range in fit_lt_unbined function

### DIFF
--- a/krcal/core/fit_lt_functions.py
+++ b/krcal/core/fit_lt_functions.py
@@ -21,6 +21,7 @@ from numpy           .linalg                 import LinAlgError
 
 from invisible_cities.core   .fit_functions  import fit
 from invisible_cities.core   .fit_functions  import expo
+from invisible_cities.core   .core_functions import in_range
 
 from . fit_functions    import expo_seed
 from . fit_functions    import chi2f
@@ -237,7 +238,8 @@ def fit_lifetime_unbined(z       : np.array,
     err   = NN  * np.ones(2)
     try:
         el = - np.log(e)
-        cc, cov = np.polyfit(z, el, deg=1, full = False, w = None, cov = True )
+        z_sel = in_range(z, *range_z)
+        cc, cov = np.polyfit(z[z_sel], el[z_sel], deg=1, full=False, w=None, cov=True)
         a, b = cc[0], cc[1]
 
         lt   = 1/a

--- a/krcal/map_builder/map_builder_functions_test.py
+++ b/krcal/map_builder/map_builder_functions_test.py
@@ -52,6 +52,7 @@ def test_scrip_runs_and_produces_correct_outputs(folder_test_dst  ,
     map_params_new = copy.copy(config.as_namespace.map_params)
     map_params_new['nmin']          = 100
     map_params_new['nStimeprofile'] = 1200
+    map_params_new['z_range']       = (0, 10000)
     config.update(dict(folder         = folder_test_dst,
                        file_in        = test_dst_file  ,
                        file_out_map   = map_file_out   ,
@@ -166,7 +167,8 @@ def test_correct_map_with_unsorted_dst(folder_test_dst  ,
     run_number     = 7517
     config = configure('maps $ICARO/krcal/map_builder/config_LBphys.conf'.split())
     map_params_new = config.as_namespace.map_params
-    map_params_new['nmin'] = 100
+    map_params_new['nmin']    = 100
+    map_params_new['z_range'] = (0, 10000)
     config.update(dict(folder         = output_maps_tmdir,
                        file_in        = tmp_unsorted_dst ,
                        file_out_map   = map_file_unsort  ,


### PR DESCRIPTION
As @neuslopez pointed out, `fit_lt_unbined` function in `fit_lt_functions.py` doesn't work properly, since it doesn't use `z_range` parameter in order to fit (even though this magnitude is already an input).
A test is now added to show this wrong behaviour, so please, @bpalmeiro or @mmkekic check this out, and then I'll add the fix.