### PR TITLE
Bump OS on GHA

### DIFF
--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         python-version: [3.8]
         #platform: [ubuntu-18.04, macos-latest]
-        platform: [ubuntu-20.04]
+        platform: [ubuntu-24.04]
     runs-on: ${{ matrix.platform }}
 
     steps:
@@ -28,8 +28,8 @@ jobs:
       run: |
         cd ..
         git clone https://github.com/next-exp/IC.git
- 
-    
+
+
     - name: Run tests
       run: |
         cd ..

--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Get LFS files
       run: git lfs pull
     # - name: Fix Conda permissions on macOS

--- a/krcal/core/fit_lt_functions.py
+++ b/krcal/core/fit_lt_functions.py
@@ -274,7 +274,7 @@ def fit_lifetime_unbined(z       : np.array,
         logging.warn(f'Type error found in fit_lifetime_unbined: not enough events for fit')
         valid = False
 
-    except LinAlgError:
+    except SystemError:
         logging.warn(f'LinAlgError error found in fit_lifetime_unbined: not enough events for fit')
         valid = False
 


### PR DESCRIPTION
GHA no longer supports ubuntu 20, so we bump it to 24.04.
Somehow, this implies a change in the type of a Exception in numpy, which is fixed accordingly.